### PR TITLE
Updated scripts for MDC v1.12 and fixed typos.

### DIFF
--- a/run_rs232_sims.yml
+++ b/run_rs232_sims.yml
@@ -10,7 +10,7 @@ tasks:
     outputs:
       working:
         - name: everything
-          path: /
+          path: ./
   - name: run1
     depends: [comp]
     fanout:
@@ -25,7 +25,7 @@ tasks:
     inputs:
       working:
         - name: comp.everything
-          path: /
+          path: ./
     outputs:
       artifacts:
         - name: sim_log

--- a/run_sequentially.ps1
+++ b/run_sequentially.ps1
@@ -12,7 +12,7 @@ dvhcom +acc+b -vhdl2008 -lib work -f filelist.txt
 
 dvlcom +acc+b +incdir+.\source\+.\sv\ dbg_link\sv_sim\sv\*.sv
 
-dsim +acc+b -lib work -top work.tb_top -gen_image image
+dsim +acc+b -lib work -top work.tb_top -genimage image
 
 $end_time = Get-Date -UFormat %s
 Write-Host "Build time was $([int]$end_time - [int]$start_time) seconds."

--- a/run_sequentially.sh
+++ b/run_sequentially.sh
@@ -11,6 +11,8 @@ dlib map -lib ieee ${STD_LIBS}/ieee08
 dvhcom +acc+b -vhdl2008 -lib work -f filelist.txt
 
 dvlcom +acc+b +incdir+./source/+./sv/ dbg_link/sv_sim/sv/*.sv
+
+dsim +acc+b -lib work -top work.tb_top -genimage image
  
 end_time=`date '+%s'`
 secs=$((end_time-start_time))
@@ -20,7 +22,7 @@ start_time=`date '+%s'`
 
 for i in {0..31};
 do
-    dsim +acc+b -lib work -top work.tb_top -sv_seed $i -l logs/dsim$i.log
+    dsim -image image -sv_seed $i -l logs/dsim$i.log
     echo ""
     echo ""
 done


### PR DESCRIPTION
1. _run_rs232_sims.yml_: Changed root paths from `/` to `./` to comply with MDC v1.12. Successfully tested on Windows.
2. _run_sequentially.ps1_: Fixed typo that prevented successful execution of script. Successfully tested on Windows.
3. _run_sequentially.sh_: Ported changes from PS script to Bash script. Untested.